### PR TITLE
Replace Comment In Private Constructor with an `UnsupportedOperationException` Throwable

### DIFF
--- a/src/main/java/com/squareup/squash/SquashBacktrace.java
+++ b/src/main/java/com/squareup/squash/SquashBacktrace.java
@@ -25,7 +25,7 @@ import java.util.Map;
 public final class SquashBacktrace {
 
   private SquashBacktrace() {
-    // Should not be instantiated: this is a utility class.
+    throw new UnsupportedOperationException("Should not be instantiated: this is a utility class");
   }
 
   public static List<SquashException> getBacktraces(Throwable error) {


### PR DESCRIPTION
Hi,

I think replacing the comment in the private constructor with an `UnsupportedOperationException` throwable is a better way to communicate the intent.
