### PR TITLE
Unit Tests For SquashBacktrace.populatenestedexceptions()

### DIFF
--- a/src/test/java/com/squareup/squash/SquashBacktrace_PopulateNestedExceptionsTest.java
+++ b/src/test/java/com/squareup/squash/SquashBacktrace_PopulateNestedExceptionsTest.java
@@ -1,16 +1,16 @@
 // Copyright 2012 Square Inc.
-// //
-// //    Licensed under the Apache License, Version 2.0 (the "License");
-// //    you may not use this file except in compliance with the License.
-// //    You may obtain a copy of the License at
-// //
-// //        http://www.apache.org/licenses/LICENSE-2.0
-// //
-// //    Unless required by applicable law or agreed to in writing, software
-// //    distributed under the License is distributed on an "AS IS" BASIS,
-// //    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// //    See the License for the specific language governing permissions and
-// //    limitations under the License.
+//
+//    Licensed under the Apache License, Version 2.0 (the "License");
+//    you may not use this file except in compliance with the License.
+//    You may obtain a copy of the License at
+//
+//        http://www.apache.org/licenses/LICENSE-2.0
+//
+//    Unless required by applicable law or agreed to in writing, software
+//    distributed under the License is distributed on an "AS IS" BASIS,
+//    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//    See the License for the specific language governing permissions and
+//    limitations under the License.
 package com.squareup.squash;
 
 import java.util.List;

--- a/src/test/java/com/squareup/squash/SquashBacktrace_PopulateNestedExceptionsTest.java
+++ b/src/test/java/com/squareup/squash/SquashBacktrace_PopulateNestedExceptionsTest.java
@@ -49,24 +49,32 @@ public class SquashBacktrace_PopulateNestedExceptionsTest{
   }
 
   @Test public void populateNestedException_WhenGivenThrowableWithOneNestedException_ReturnsItsNestedException() {
+    String expectedClassName = Throwable.class.getName();
     String expectedExceptionMessage = "Nested Exception";
     Throwable expectedCause = new Throwable(expectedExceptionMessage);
     Throwable parent = new Throwable(expectedCause);
-    List<SquashBacktrace.NestedException> actualNestedExceptions = new ArrayList<SquashBacktrace.NestedException>();
+
+    List<SquashBacktrace.NestedException> actualNestedExceptions = listOfNestedExceptions(0);
     SquashBacktrace.populateNestedExceptions(actualNestedExceptions, parent);
-    
-    assertThat(actualNestedExceptions).hasSize(1);
-    assertThat(actualNestedExceptions.get(0)).isNotNull();
+    assertNestedExceptionAttributes(actualNestedExceptions.get(0), expectedExceptionMessage, expectedClassName);
+  }
 
-    String expectedClassName = parent.getClass().getName();
-    assertThat(actualNestedExceptions.get(0).class_name).isEqualTo(expectedClassName);
-    assertThat(actualNestedExceptions.get(0).message).isEqualTo(expectedExceptionMessage);
+  private void assertNestedExceptionAttributes(SquashBacktrace.NestedException fixture, String expectedExceptionMessage, String expectedClassName){
+    assertThat(fixture).isNotNull();
+    assertThat(fixture.class_name).isEqualTo(expectedClassName);
+    assertThat(fixture.message).isEqualTo(expectedExceptionMessage);
+    assertThat(fixture.ivars).isNotNull();
+    assertNestedExceptionBacktraces(fixture);
+  }
 
-    assertThat(actualNestedExceptions.get(0).backtraces).isNotEmpty();
-    assertThat(actualNestedExceptions.get(0).backtraces).hasSize(1);
-    assertThat(actualNestedExceptions.get(0).backtraces.get(0)).isNotNull();
-    assertThat(actualNestedExceptions.get(0).backtraces.get(0).getClass()).isEqualTo(SquashBacktrace.SquashException.class);
+  private void assertNestedExceptionBacktraces(SquashBacktrace.NestedException fixture){
+    assertThat(fixture.backtraces).isNotEmpty();
+    assertThat(fixture.backtraces).hasSize(1);
+    assertSquashExceptionAttributes(fixture.backtraces.get(0));
+  }
 
-    assertThat(actualNestedExceptions.get(0).ivars).isNotNull();
+  private void assertSquashExceptionAttributes(SquashBacktrace.SquashException fixture){
+    assertThat(fixture).isNotNull();
+    assertThat(fixture.getClass()).isEqualTo(SquashBacktrace.SquashException.class);
   }
 }

--- a/src/test/java/com/squareup/squash/SquashBacktrace_PopulateNestedExceptionsTest.java
+++ b/src/test/java/com/squareup/squash/SquashBacktrace_PopulateNestedExceptionsTest.java
@@ -24,27 +24,28 @@ import static org.fest.assertions.Assertions.assertThat;
 public class SquashBacktrace_PopulateNestedExceptionsTest{
 
   @Test public void populateNestedException_WhenGivenNullThrowable_NestedExceptionListRemainsUnchanged(){
-    List<SquashBacktrace.NestedException> emptyList = new ArrayList<SquashBacktrace.NestedException>();
+    List<SquashBacktrace.NestedException> emptyList = listOfNestedExceptions(0);
     SquashBacktrace.populateNestedExceptions(emptyList, null);
     assertThat(emptyList).isEmpty();
 
-    List<SquashBacktrace.NestedException> listOfOne = new ArrayList<SquashBacktrace.NestedException>();
-    listOfOne.add(new SquashBacktrace.NestedException(this.getClass().getName(), "Nested Exception 1", null, null));
+    List<SquashBacktrace.NestedException> listOfOne = listOfNestedExceptions(1);
     SquashBacktrace.populateNestedExceptions(listOfOne, null);
     assertThat(listOfOne).hasSize(1);
 
-    List<SquashBacktrace.NestedException> listOfTwo = new ArrayList<SquashBacktrace.NestedException>();
-    listOfTwo.add(new SquashBacktrace.NestedException(this.getClass().getName(), "Nested Exception 1", null, null));
-    listOfTwo.add(new SquashBacktrace.NestedException(this.getClass().getName(), "Nested Exception 2", null, null));
+    List<SquashBacktrace.NestedException> listOfTwo = listOfNestedExceptions(2);
     SquashBacktrace.populateNestedExceptions(listOfTwo, null);
     assertThat(listOfTwo).hasSize(2);
 
-    List<SquashBacktrace.NestedException> listOfThree = new ArrayList<SquashBacktrace.NestedException>();
-    listOfThree.add(new SquashBacktrace.NestedException(this.getClass().getName(), "Nested Exception 1", null, null));
-    listOfThree.add(new SquashBacktrace.NestedException(this.getClass().getName(), "Nested Exception 2", null, null));
-    listOfThree.add(new SquashBacktrace.NestedException(this.getClass().getName(), "Nested Exception 3", null, null));
+    List<SquashBacktrace.NestedException> listOfThree = listOfNestedExceptions(3);
     SquashBacktrace.populateNestedExceptions(listOfThree, null);
     assertThat(listOfThree).hasSize(3);
+  }
+
+  private List<SquashBacktrace.NestedException> listOfNestedExceptions(int count){
+    List<SquashBacktrace.NestedException> nestedExceptions = new ArrayList<SquashBacktrace.NestedException>();
+    for(int i = 0; i < count; i++)
+      nestedExceptions.add(new SquashBacktrace.NestedException(this.getClass().getName(), "Nested Exception 1", null, null));
+    return nestedExceptions;
   }
 
   @Test public void populateNestedException_WhenGivenThrowableWithOneNestedException_ReturnsItsNestedException() {

--- a/src/test/java/com/squareup/squash/SquashBacktrace_PopulateNestedExceptionsTest.java
+++ b/src/test/java/com/squareup/squash/SquashBacktrace_PopulateNestedExceptionsTest.java
@@ -11,17 +11,25 @@
 // //    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // //    See the License for the specific language governing permissions and
 // //    limitations under the License.
-
 package com.squareup.squash;
 
 import java.util.List;
 import java.util.ArrayList;
 
 import org.junit.Test;
+import org.junit.Before;
 
 import static org.fest.assertions.Assertions.assertThat; 
 
 public class SquashBacktrace_PopulateNestedExceptionsTest{
+
+  private String expectedClassName;
+  private Throwable parent;
+
+  @Before public void setUp(){
+    expectedClassName = Throwable.class.getName();
+    parent = new Throwable(); 
+  }
 
   @Test public void populateNestedException_WhenGivenNullThrowable_NestedExceptionsRemainsUnchanged(){
     List<SquashBacktrace.NestedException> emptyList = new ArrayList<SquashBacktrace.NestedException>();
@@ -30,17 +38,60 @@ public class SquashBacktrace_PopulateNestedExceptionsTest{
   }
 
   @Test public void populateNestedException_WhenGivenThrowableWithOneNestedException_ReturnsItsNestedException() {
-    String expectedClassName = Throwable.class.getName();
-    String expectedExceptionMessage = "Nested Exception";
-    Throwable expectedCause = new Throwable(expectedExceptionMessage);
-    Throwable parent = new Throwable(expectedCause);
-
+    parent.initCause(nestedThrowablesWithDepths(1, null));
     List<SquashBacktrace.NestedException> actualNestedExceptions = new ArrayList<SquashBacktrace.NestedException>();
     SquashBacktrace.populateNestedExceptions(actualNestedExceptions, parent);
-    assertNestedExceptionAttributes(actualNestedExceptions.get(0), expectedExceptionMessage, expectedClassName);
+    assertNestedExceptions(actualNestedExceptions);
   }
 
-  private void assertNestedExceptionAttributes(SquashBacktrace.NestedException fixture, String expectedExceptionMessage, String expectedClassName){
+  @Test public void populateNestedException_WhenGivenThrowableWithFiveNestedException_ReturnsAllNestedExceptions() {
+    parent.initCause(nestedThrowablesWithDepths(5, null));
+    List<SquashBacktrace.NestedException> actualNestedExceptions = new ArrayList<SquashBacktrace.NestedException>();
+    SquashBacktrace.populateNestedExceptions(actualNestedExceptions, parent);
+    assertNestedExceptions(actualNestedExceptions);
+  }
+
+  @Test public void populateNestedException_WhenGivenThrowableWithTenNestedException_ReturnsAllNestedExceptions() {
+    parent.initCause(nestedThrowablesWithDepths(10, null));
+    List<SquashBacktrace.NestedException> actualNestedExceptions = new ArrayList<SquashBacktrace.NestedException>();
+    SquashBacktrace.populateNestedExceptions(actualNestedExceptions, parent);
+    assertNestedExceptions(actualNestedExceptions);
+  }
+
+  @Test public void populateNestedException_WhenGivenThrowableWithThirtyNestedException_ReturnsAllNestedExceptions() {
+    parent.initCause(nestedThrowablesWithDepths(30, null));
+    List<SquashBacktrace.NestedException> actualNestedExceptions = new ArrayList<SquashBacktrace.NestedException>();
+    SquashBacktrace.populateNestedExceptions(actualNestedExceptions, parent);
+    assertNestedExceptions(actualNestedExceptions);
+  }
+
+  @Test public void populateNestedException_WhenGivenThrowableWithSixtyNestedException_ReturnsAllNestedExceptions() {
+    parent.initCause(nestedThrowablesWithDepths(60, null));
+    List<SquashBacktrace.NestedException> actualNestedExceptions = new ArrayList<SquashBacktrace.NestedException>();
+    SquashBacktrace.populateNestedExceptions(actualNestedExceptions, parent);
+    assertNestedExceptions(actualNestedExceptions);
+  }
+
+  private Throwable nestedThrowablesWithDepths(int depth, Throwable cause) {
+    if(depth == 0)
+      return cause;
+
+    String message = "Level[" + depth + "]: This Is A Nested Exception";
+    Throwable throwable = new Throwable(message);
+    if (cause != null)
+      throwable.initCause(cause);
+    return nestedThrowablesWithDepths(depth - 1, throwable);
+  }
+
+  private void assertNestedExceptions(List<SquashBacktrace.NestedException> nestedExceptions){
+    for(int i = 0; i < nestedExceptions.size(); i++) {
+      int depth = i + 1;
+      String expectedMessage = "Level[" + depth + "]: This Is A Nested Exception";
+      assertNestedExceptionAttributes(nestedExceptions.get(i), expectedMessage);
+    }
+  }
+
+  private void assertNestedExceptionAttributes(SquashBacktrace.NestedException fixture, String expectedExceptionMessage){
     assertThat(fixture).isNotNull();
     assertThat(fixture.class_name).isEqualTo(expectedClassName);
     assertThat(fixture.message).isEqualTo(expectedExceptionMessage);

--- a/src/test/java/com/squareup/squash/SquashBacktrace_PopulateNestedExceptionsTest.java
+++ b/src/test/java/com/squareup/squash/SquashBacktrace_PopulateNestedExceptionsTest.java
@@ -24,28 +24,9 @@ import static org.fest.assertions.Assertions.assertThat;
 public class SquashBacktrace_PopulateNestedExceptionsTest{
 
   @Test public void populateNestedException_WhenGivenNullThrowable_NestedExceptionListRemainsUnchanged(){
-    List<SquashBacktrace.NestedException> emptyList = listOfNestedExceptions(0);
+    List<SquashBacktrace.NestedException> emptyList = new ArrayList<SquashBacktrace.NestedException>();
     SquashBacktrace.populateNestedExceptions(emptyList, null);
     assertThat(emptyList).isEmpty();
-
-    List<SquashBacktrace.NestedException> listOfOne = listOfNestedExceptions(1);
-    SquashBacktrace.populateNestedExceptions(listOfOne, null);
-    assertThat(listOfOne).hasSize(1);
-
-    List<SquashBacktrace.NestedException> listOfTwo = listOfNestedExceptions(2);
-    SquashBacktrace.populateNestedExceptions(listOfTwo, null);
-    assertThat(listOfTwo).hasSize(2);
-
-    List<SquashBacktrace.NestedException> listOfThree = listOfNestedExceptions(3);
-    SquashBacktrace.populateNestedExceptions(listOfThree, null);
-    assertThat(listOfThree).hasSize(3);
-  }
-
-  private List<SquashBacktrace.NestedException> listOfNestedExceptions(int count){
-    List<SquashBacktrace.NestedException> nestedExceptions = new ArrayList<SquashBacktrace.NestedException>();
-    for(int i = 0; i < count; i++)
-      nestedExceptions.add(new SquashBacktrace.NestedException(this.getClass().getName(), "Nested Exception 1", null, null));
-    return nestedExceptions;
   }
 
   @Test public void populateNestedException_WhenGivenThrowableWithOneNestedException_ReturnsItsNestedException() {
@@ -54,7 +35,7 @@ public class SquashBacktrace_PopulateNestedExceptionsTest{
     Throwable expectedCause = new Throwable(expectedExceptionMessage);
     Throwable parent = new Throwable(expectedCause);
 
-    List<SquashBacktrace.NestedException> actualNestedExceptions = listOfNestedExceptions(0);
+    List<SquashBacktrace.NestedException> actualNestedExceptions = new ArrayList<SquashBacktrace.NestedException>();
     SquashBacktrace.populateNestedExceptions(actualNestedExceptions, parent);
     assertNestedExceptionAttributes(actualNestedExceptions.get(0), expectedExceptionMessage, expectedClassName);
   }

--- a/src/test/java/com/squareup/squash/SquashBacktrace_PopulateNestedExceptionsTest.java
+++ b/src/test/java/com/squareup/squash/SquashBacktrace_PopulateNestedExceptionsTest.java
@@ -76,5 +76,8 @@ public class SquashBacktrace_PopulateNestedExceptionsTest{
   private void assertSquashExceptionAttributes(SquashBacktrace.SquashException fixture){
     assertThat(fixture).isNotNull();
     assertThat(fixture.getClass()).isEqualTo(SquashBacktrace.SquashException.class);
+    assertThat(fixture.name).isNotNull();
+    assertThat(fixture.faulted).isEqualTo(true);
+    assertThat(fixture.backtrace).isNotNull();
   }
 }

--- a/src/test/java/com/squareup/squash/SquashBacktrace_PopulateNestedExceptionsTest.java
+++ b/src/test/java/com/squareup/squash/SquashBacktrace_PopulateNestedExceptionsTest.java
@@ -23,7 +23,7 @@ import static org.fest.assertions.Assertions.assertThat;
 
 public class SquashBacktrace_PopulateNestedExceptionsTest{
 
-  @Test public void populateNestedException_WhenGivenNullThrowable_NestedExceptionListRemainsUnchanged(){
+  @Test public void populateNestedException_WhenGivenNullThrowable_NestedExceptionsRemainsUnchanged(){
     List<SquashBacktrace.NestedException> emptyList = new ArrayList<SquashBacktrace.NestedException>();
     SquashBacktrace.populateNestedExceptions(emptyList, null);
     assertThat(emptyList).isEmpty();

--- a/src/test/java/com/squareup/squash/SquashBacktrace_PopulateNestedExceptionsTest.java
+++ b/src/test/java/com/squareup/squash/SquashBacktrace_PopulateNestedExceptionsTest.java
@@ -46,4 +46,26 @@ public class SquashBacktrace_PopulateNestedExceptionsTest{
     SquashBacktrace.populateNestedExceptions(listOfThree, null);
     assertThat(listOfThree).hasSize(3);
   }
+
+  @Test public void populateNestedException_WhenGivenThrowableWithOneNestedException_ReturnsItsNestedException() {
+    String expectedExceptionMessage = "Nested Exception";
+    Throwable expectedCause = new Throwable(expectedExceptionMessage);
+    Throwable parent = new Throwable(expectedCause);
+    List<SquashBacktrace.NestedException> actualNestedExceptions = new ArrayList<SquashBacktrace.NestedException>();
+    SquashBacktrace.populateNestedExceptions(actualNestedExceptions, parent);
+    
+    assertThat(actualNestedExceptions).hasSize(1);
+    assertThat(actualNestedExceptions.get(0)).isNotNull();
+
+    String expectedClassName = parent.getClass().getName();
+    assertThat(actualNestedExceptions.get(0).class_name).isEqualTo(expectedClassName);
+    assertThat(actualNestedExceptions.get(0).message).isEqualTo(expectedExceptionMessage);
+
+    assertThat(actualNestedExceptions.get(0).backtraces).isNotEmpty();
+    assertThat(actualNestedExceptions.get(0).backtraces).hasSize(1);
+    assertThat(actualNestedExceptions.get(0).backtraces.get(0)).isNotNull();
+    assertThat(actualNestedExceptions.get(0).backtraces.get(0).getClass()).isEqualTo(SquashBacktrace.SquashException.class);
+
+    assertThat(actualNestedExceptions.get(0).ivars).isNotNull();
+  }
 }

--- a/src/test/java/com/squareup/squash/SquashBacktrace_PopulateNestedExceptionsTest.java
+++ b/src/test/java/com/squareup/squash/SquashBacktrace_PopulateNestedExceptionsTest.java
@@ -1,0 +1,49 @@
+// Copyright 2012 Square Inc.
+// //
+// //    Licensed under the Apache License, Version 2.0 (the "License");
+// //    you may not use this file except in compliance with the License.
+// //    You may obtain a copy of the License at
+// //
+// //        http://www.apache.org/licenses/LICENSE-2.0
+// //
+// //    Unless required by applicable law or agreed to in writing, software
+// //    distributed under the License is distributed on an "AS IS" BASIS,
+// //    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// //    See the License for the specific language governing permissions and
+// //    limitations under the License.
+
+package com.squareup.squash;
+
+import java.util.List;
+import java.util.ArrayList;
+
+import org.junit.Test;
+
+import static org.fest.assertions.Assertions.assertThat; 
+
+public class SquashBacktrace_PopulateNestedExceptionsTest{
+
+  @Test public void populateNestedException_WhenGivenNullThrowable_NestedExceptionListRemainsUnchanged(){
+    List<SquashBacktrace.NestedException> emptyList = new ArrayList<SquashBacktrace.NestedException>();
+    SquashBacktrace.populateNestedExceptions(emptyList, null);
+    assertThat(emptyList).isEmpty();
+
+    List<SquashBacktrace.NestedException> listOfOne = new ArrayList<SquashBacktrace.NestedException>();
+    listOfOne.add(new SquashBacktrace.NestedException(this.getClass().getName(), "Nested Exception 1", null, null));
+    SquashBacktrace.populateNestedExceptions(listOfOne, null);
+    assertThat(listOfOne).hasSize(1);
+
+    List<SquashBacktrace.NestedException> listOfTwo = new ArrayList<SquashBacktrace.NestedException>();
+    listOfTwo.add(new SquashBacktrace.NestedException(this.getClass().getName(), "Nested Exception 1", null, null));
+    listOfTwo.add(new SquashBacktrace.NestedException(this.getClass().getName(), "Nested Exception 2", null, null));
+    SquashBacktrace.populateNestedExceptions(listOfTwo, null);
+    assertThat(listOfTwo).hasSize(2);
+
+    List<SquashBacktrace.NestedException> listOfThree = new ArrayList<SquashBacktrace.NestedException>();
+    listOfThree.add(new SquashBacktrace.NestedException(this.getClass().getName(), "Nested Exception 1", null, null));
+    listOfThree.add(new SquashBacktrace.NestedException(this.getClass().getName(), "Nested Exception 2", null, null));
+    listOfThree.add(new SquashBacktrace.NestedException(this.getClass().getName(), "Nested Exception 3", null, null));
+    SquashBacktrace.populateNestedExceptions(listOfThree, null);
+    assertThat(listOfThree).hasSize(3);
+  }
+}


### PR DESCRIPTION
Hi,

I have added some unit tests for `SquashBacktrace.populateNestedExceptions()`. I see that there is already a set of comprehensive test cases under `SquashEntryTest`. But I think separating out the utility test cases into their own test classes will help to improve readability and maintainability. 

I also added a private method named `nestedExceptionsWithDepths()` to help create exceptions with N-level deep nested causes.
